### PR TITLE
Set enableDefaultPath to false in NixOS user service

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,7 @@
                 partOf = [ "graphical-session.target" ];
                 wants = [ "graphical-session.target" ];
                 after = [ "graphical-session.target" ];
+                enableDefaultPath = false;
                 serviceConfig = {
                   Type = "simple";
                   Restart = "on-failure";


### PR DESCRIPTION
When `services.piri.enable = true;` is set in NixOS config, [enableDefaultPath](https://mynixos.com/nixpkgs/option/systemd.user.services.<name>.enableDefaultPath) is set to `true` by default for `systemd.user.services.piri`.

This becomes a problem when using Singleton, because `Environment="PATH=..."` defined by `enableDefaultPath` overrides the `PATH` from user environment, resulting in piri daemon being unable to resolve paths to binaries (e.g. `firefox` in `/etc/profiles/per-user/user/bin` or `md.obsidian.Obsidian` in `/home/user/.local/share/flatpak/exports/bin`).

Setting `enableDefaultPath` to `false` allows the user service to inherit `PATH` from user environment and launch applications as expected.